### PR TITLE
Fix for MIC field overflowing the bottom of the panel #218

### DIFF
--- a/RIGS/templates/RIGS/event_form.html
+++ b/RIGS/templates/RIGS/event_form.html
@@ -63,7 +63,7 @@
                         } else {
                             $('.form-is_rig').slideDown();
                         }
-                        $('.form-hws').css('overflow', 'visible');
+                        $('.form-hws, .form-hws .form-is_rig').css('overflow', 'visible');
                     } else {
                         $('#{{form.is_rig.auto_id}}').prop('checked', false);
                         $('.form-is_rig').slideUp();


### PR DESCRIPTION
Would liked to have done this in CSS, but alas the slider decided it was not a thing. Wasn't the suggested fix but found the correct CSS selector and added that
