### PR TITLE
Fix table display issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Then load the sample data using the command:
 python manage.py generateSampleData
 ```
 4 user accounts are created for convenience:
+
 |Username |Password |
 |---------|---------|
 |superuser|superuser|


### PR DESCRIPTION
Small adjustment to make GitHub markdown display the table in the README.
