### PR TITLE
Fix ical end dates being wrong by 24 hours

### DIFF
--- a/RIGS/ical.py
+++ b/RIGS/ical.py
@@ -99,7 +99,7 @@ class CalendarICS(ICalFeed):
         return item.earliest_time
 
     def item_end_datetime(self, item):
-        if isinstance(item.latest_time, datetime.date):  # Ical end_datetime is non-inclusive, so add a day
+        if type(item.latest_time) == datetime.date:  # Ical end_datetime is non-inclusive, so add a day
             return item.latest_time + datetime.timedelta(days=1)
 
         return item.latest_time
@@ -137,7 +137,7 @@ class CalendarICS(ICalFeed):
         # if item.notes:  // Need to add proper keyholder checks before this gets put back
         #     desc += 'Notes:\n'+item.notes+'\n\n'
 
-        base_url = "http://rigs.nottinghamtec.co.uk"
+        base_url = "https://rigs.nottinghamtec.co.uk"
         desc += 'URL = ' + base_url + str(item.get_absolute_url())
 
         return desc

--- a/RIGS/test_functional.py
+++ b/RIGS/test_functional.py
@@ -834,7 +834,9 @@ class IcalTest(LiveServerTestCase):
                                     description="start past 1 week with end past")
         models.Event.objects.create(name="TE E6", status=models.Event.BOOKED,
                                     start_date=date.today() - timedelta(days=2),
-                                    end_date=date.today() + timedelta(days=2), description="start past, end future")
+                                    start_time=time(8, 00),
+                                    end_date=date.today() + timedelta(days=2),
+                                    end_time=time(23, 00), description="start past, end future")
         models.Event.objects.create(name="TE E7", status=models.Event.BOOKED,
                                     start_date=date.today() + timedelta(days=2),
                                     end_date=date.today() + timedelta(days=2), description="start + end in future")
@@ -924,6 +926,8 @@ class IcalTest(LiveServerTestCase):
         # Awesome - all seems to work
 
     def testICSFiles(self):
+        specialEvent = models.Event.objects.get(name="TE E6")
+
         # Requests address
         self.browser.get(self.live_server_url + '/user/')
         # Gets redirected to login
@@ -952,6 +956,10 @@ class IcalTest(LiveServerTestCase):
                 self.assertContains(response, "TE E" + str(test) + " ")
             else:
                 self.assertNotContains(response, "TE E" + str(test) + " ")
+
+        # Check that times have been included correctly
+        self.assertContains(response, specialEvent.start_date.strftime('%Y%m%d') + 'T' + specialEvent.start_time.strftime('%H%M%S'))
+        self.assertContains(response, specialEvent.end_date.strftime('%Y%m%d') + 'T' + specialEvent.end_time.strftime('%H%M%S'))
 
         # Only dry hires
         self.browser.find_element_by_xpath("//input[@value='rig']").click()


### PR DESCRIPTION
I have literally no idea how this ever worked in the past. Python's `datetime.datetime` inherits from `datetime.date`, so using `instanceof` to check whether something is a date or a datetime is never going to work. 

Anyway, this is a fairly simple fix