### PR TITLE
Clear "checking in by" on event duplication

### DIFF
--- a/PyRIGS/settings.py
+++ b/PyRIGS/settings.py
@@ -35,6 +35,7 @@ if STAGING:
 if DEBUG:
     ALLOWED_HOSTS.append('localhost')
     ALLOWED_HOSTS.append('example.com')
+    ALLOWED_HOSTS.append('127.0.0.1')
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 if not DEBUG:

--- a/RIGS/rigboard.py
+++ b/RIGS/rigboard.py
@@ -138,7 +138,7 @@ class EventDuplicate(EventUpdate):
         old = super(EventDuplicate, self).get_object(queryset)  # Get the object (the event you're duplicating)
         new = copy.copy(old)  # Make a copy of the object in memory
         new.based_on = old  # Make the new event based on the old event
-        new.purchase_order = None # Remove old PO
+        new.purchase_order = None  # Remove old PO
 
         # Clear checked in by if it's a dry hire
         if new.dry_hire is True:

--- a/RIGS/rigboard.py
+++ b/RIGS/rigboard.py
@@ -138,7 +138,11 @@ class EventDuplicate(EventUpdate):
         old = super(EventDuplicate, self).get_object(queryset)  # Get the object (the event you're duplicating)
         new = copy.copy(old)  # Make a copy of the object in memory
         new.based_on = old  # Make the new event based on the old event
-        new.purchase_order = None
+        new.purchase_order = None # Remove old PO
+
+        # Clear checked in by if it's a dry hire
+        if new.dry_hire is True:
+            new.checked_in_by = None
 
         # Remove all the authorisation information from the new event
         new.auth_request_to = None


### PR DESCRIPTION
Haven't added any tests as all the tests for duplication aren't dry hires and I don't want to try adding new ones.