### PR TITLE
Fix typo in PSCC

### DIFF
--- a/RIGS/templates/partials/ec_power_info.html
+++ b/RIGS/templates/partials/ec_power_info.html
@@ -33,8 +33,8 @@
             <thead>
                 <tr>
                     <th scope="row">Distro</th>
-                    <th scope="row">Max PSSC with Single Phase Supply (kA)</th>
-                    <th scope="row">Max PSSC with Three Phase Supply (kA)</th>
+                    <th scope="row">Max PSCC with Single Phase Supply (kA)</th>
+                    <th scope="row">Max PSCC with Three Phase Supply (kA)</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Circuit is spelt Circuit, not Sircuit.
