### PR TITLE
Generate PDFs from Power Test Records

### DIFF
--- a/RIGS/models.py
+++ b/RIGS/models.py
@@ -942,7 +942,7 @@ class PowerTestRecord(ReviewableModel, RevisionMixin):
     @property
     def activity_feed_string(self):
         return str(self.event)
-    
+
     @property
     def name(self):
         return f"Power Test Record - {self.event}"

--- a/RIGS/models.py
+++ b/RIGS/models.py
@@ -942,6 +942,10 @@ class PowerTestRecord(ReviewableModel, RevisionMixin):
     @property
     def activity_feed_string(self):
         return str(self.event)
+    
+    @property
+    def name(self):
+        return f"Power Test Record - {self.event}"
 
 
 class EventCheckIn(models.Model):

--- a/RIGS/templates/base_print.xml
+++ b/RIGS/templates/base_print.xml
@@ -22,6 +22,9 @@
         <paraStyle name="center" alignment="center"/>
         <paraStyle name="page-head" alignment="center" fontName="OpenSans-Bold" fontSize="16" leading="18" spaceAfter="0"/>
 
+        {% block extrastyles %}
+        {% endblock %}
+
         <paraStyle name="style.event_description" fontName="OpenSans" textColor="DarkGray" />
         <paraStyle name="style.item_description" fontName="OpenSans" textColor="DarkGray" leftIndent="10" />
         <paraStyle name="style.specific_description" fontName="OpenSans" textColor="DarkGray" fontSize="10" />

--- a/RIGS/templates/base_print.xml
+++ b/RIGS/templates/base_print.xml
@@ -140,6 +140,7 @@
         <nextFrame/>
         {% block content %}
         {% endblock %}
+        <namedString id="lastPage"><pageNumber/></namedString>
     </story>
 
 </document>

--- a/RIGS/templates/hs/power_detail.html
+++ b/RIGS/templates/hs/power_detail.html
@@ -165,6 +165,7 @@
     </div>
 </div>
 <div class="col-12 text-right">
+{% button 'print' 'pt_print' object.pk %}
 {% button 'edit' url='pt_edit' pk=object.pk %}
 {% button 'view' url='event_detail' pk=object.event.pk text="Event" %}
 {% include 'partials/review_status.html' with perm=perms.RIGS.review_power review='pt_review' %}

--- a/RIGS/templates/hs/power_print.xml
+++ b/RIGS/templates/hs/power_print.xml
@@ -1,0 +1,170 @@
+{% extends 'base_print.xml' %}
+{% load filters %}
+
+{% block extrastyles %}
+<paraStyle name="style.powerReviewed" alignment="center" backColor="green" textColor="white"/>
+<paraStyle name="style.powerUnreviewed" alignment="center" backColor="red" textColor="white"/>
+
+<blockTableStyle id="powerTable">
+    <blockValign value="middle"/>
+    <lineStyle kind="LINEABOVE" colorName="black" thickness="1"/>
+    <lineStyle kind="LINEBELOW" colorName="black" thickness="1"/>
+    <lineStyle kind="LINEAFTER" colorName="black" thickness="1"/>
+    <lineStyle kind="LINEBEFORE" colorName="black" thickness="1"/>
+</blockTableStyle>
+{% endblock %}
+
+{% block content %}
+<spacer length="15"/>
+<h1>Power Test Record for <strong>{{ object.event }}</strong></h1>
+<spacer length="15"/>
+<h2>Client: {{ object.event.person|default:object.event.organisation }} | Venue: {{ object.event.venue }} | MIC: {{ object.event.mic }}</h2>
+<spacer length="15"/>
+<hr/>
+<spacer length="15"/>
+{% if object.reviewed_by %}
+    <para style="style.powerReviewed"><strong>Reviewed by: {{ object.reviewed_by }} at {{ object.reviewed_at|date:"D d/m/Y" }}</strong></para>
+{% else %}
+    <para style="style.powerUnreviewed"><strong>Power test results not yet reviewed</strong></para>
+{% endif %}
+<spacer length="15"/>
+<hr/>
+<spacer length="15"/>
+
+<h2 fontSize="16">Power Plan Information</h2>
+<spacer length="15"/>
+
+<blockTable colWidths="250,250">
+    <tr>
+        <td><para><strong>Power MIC:</strong> {{ object.power_mic }}</para></td>
+        <td><para><strong>Venue:</strong> {{ object.event.venue }}</para></td>
+
+    </tr>
+    <tr>
+        <td><para><strong>Event Date:</strong> {{ object.event.start_date |date:"D d/m/Y" }}</para></td>
+        <td><para><strong>Generators:</strong> {{ object.event.riskassessment.generators|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Power Test taken at:</strong> {{ object.date_created|date:"D d/m/Y H:i" }}</para></td>
+        <td><para><strong>Other Companies Power:</strong> {{ object.event.riskassessment.other_companies_power|yesno|capfirst }}</para></td>
+    </tr>
+</blockTable>
+
+<spacer length="15"/>
+<hr/>
+<spacer length="15"/>
+
+<condPageBreak height="10in"/>
+
+<h2 fontSize="16">Power Test Results</h2>
+<spacer length="15"/>
+
+<para><strong>Source RCD protected?</strong> {{ object.source_rcd|yesno|capfirst }}</para>
+<para><sub>(If cable is more than 3 metres long)</sub></para>
+
+<spacer length="5"/>
+
+<para><strong>Appropriate and clear labelling on distribution and cabling?</strong> {{ object.labelling|yesno|capfirst }}</para>
+
+<spacer length="5"/>
+
+<para><strong>Equipment appropriately earthed?</strong> {{ object.source_rcd|yesno|capfirst }}</para>
+<para><sub>(truss, stage, generators etc.)</sub></para>
+
+<spacer length="5"/>
+
+<para><strong>All equipment in PAT period?</strong> {{ object.pat|yesno|capfirst }}</para>
+
+<spacer length="15"/>
+
+<h2 fontSize="14">Tests at first distro</h2>
+<spacer length="5"/>
+
+<blockTable colWidths="100,410">
+<tr>
+<td><para><strong>Voltage<br/><sub>(cube meter) / V</sub></strong></para></td>
+<td>
+    <blockTable colWidths="100,100,100" style="powerTable">
+        <tr>
+            <td><para><strong>L1 - N</strong></para></td>
+            <td><para><strong>L2 - N</strong></para></td>
+            <td><para><strong>L3 - N</strong></para></td>
+        </tr>
+        <tr>
+            <td>{{ object.fd_voltage_l1}}</td>
+            <td>{{ object.fd_voltage_l2}}</td>
+            <td>{{ object.fd_voltage_l3}}</td>
+        </tr>
+    </blockTable>
+</td>
+</tr>
+</blockTable>
+
+<spacer length="15"/>
+
+<blockTable colWidths="100,100,190,120">
+    <tr>
+        <td><para><strong>Phase Rotation<br/><sub>(if required)</sub></strong></para></td>
+        <td><para>{{ object.fd_phase_rotation|yesno|capfirst }}</para></td>
+                <td><para><strong>Earth Fault Loop Impedance (Z<sub>s</sub>) / Ω</strong></para></td>
+        <td><para>{{ object.fd_earth_fault }}</para></td>
+    </tr>
+</blockTable>
+
+<spacer length="15"/>
+
+<para><strong>Prospective Short Circuit Current / A</strong> {{ object.fd_pssc }}</para>
+
+<spacer length="15"/>
+
+<h2 fontSize="14">Tests 'Worst Case' points (at least 1 required)</h2>
+<spacer length="15"/>
+
+<blockTable colWidths="100,100,190,120" style="powerTable">
+    <tr>
+        <td><para><strong>Description</strong></para></td>
+        <td><para><strong>Polarity checked?</strong></para></td>
+        <td><para><strong>Voltage / V</strong></para></td>
+        <td><para><strong>Earth Fault Loop Impedance (Z<sub>s</sub>) / Ω</strong></para></td>
+    </tr>
+    {% if object.w1_description %}
+    <tr>
+        <td><para><strong>{{ object.w1_description }}</strong></para></td>
+        <td><para>{{ object.w1_polarity|yesno|capfirst }}</para></td>
+        <td><para>{{ object.w1_voltage }} V</para></td>
+        <td><para>{{ object.w1_earth_fault }}</para></td>
+    </tr>
+    {% endif %}
+    {% if object.w2_description %}
+    <tr>
+        <td><para><strong>{{ object.w2_description }}</strong></para></td>
+        <td><para>{{ object.w2_polarity|yesno|capfirst }}</para></td>
+        <td><para>{{ object.w2_voltage }} V</para></td>
+        <td><para>{{ object.w2_earth_fault }}</para></td>
+    </tr>
+    {% endif %}
+    {% if object.w3_description %}
+    <tr>
+        <td><para><strong>{{ object.w3_description }}</strong></para></td>
+        <td><para>{{ object.w3_polarity|yesno|capfirst }}</para></td>
+        <td><para>{{ object.w3_voltage }} V</para></td>
+        <td><para>{{ object.w3_earth_fault }}</para></td>
+    </tr>
+    {% endif %}
+</blockTable>
+
+<spacer length="15"/>
+<h2 fontSize="14">Generic Tests</h2>
+<spacer length="15"/>
+
+<blockTable colWidths="250,270" style="powerTable">
+    <tr>
+        <td><para><strong>All circuit RCDs tested?</strong><br/>(using test button)</para></td>
+        <td><para>{{ object.all_rcds_tested|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Public/performer accessible circuits tested?</strong><br/>(using socket tester)</para></td>
+        <td><para>{{ object.public_sockets_tested|yesno|capfirst }}</para></td>
+    </tr>
+</blockTable>
+{% endblock %}

--- a/RIGS/urls.py
+++ b/RIGS/urls.py
@@ -100,6 +100,7 @@ urlpatterns = [
          name='pt_edit'),
     path('event/power/<int:pk>/review/', permission_required_with_403('RIGS.review_power')(views.MarkReviewed.as_view()),
          name='pt_review', kwargs={'model': 'PowerTestRecord'}),
+    path('event/power/<int:pk>/print/', permission_required_with_403('RIGS.view_powertestrecord')(views.PowerPrint.as_view()), name='pt_print'),
 
     path('event/<int:pk>/checkin/', login_required(views.EventCheckIn.as_view()),
          name='event_checkin'),

--- a/RIGS/views/hs.py
+++ b/RIGS/views/hs.py
@@ -231,6 +231,7 @@ class RAPrint(PrintView):
         context['filename'] = f"EventSpecificRiskAssessment_for_{context['object'].event.display_id}.pdf"
         return context
 
+
 class PowerPrint(PrintView):
     model = models.PowerTestRecord
     template_name = 'hs/power_print.xml'
@@ -239,6 +240,7 @@ class PowerPrint(PrintView):
         context = super().get_context_data(**kwargs)
         context['filename'] = f"PowerTestRecord_for_{context['object'].event.display_id}.pdf"
         return context
+
 
 class EventCheckIn(generic.CreateView, ModalURLMixin):
     model = models.EventCheckIn

--- a/RIGS/views/hs.py
+++ b/RIGS/views/hs.py
@@ -231,6 +231,14 @@ class RAPrint(PrintView):
         context['filename'] = f"EventSpecificRiskAssessment_for_{context['object'].event.display_id}.pdf"
         return context
 
+class PowerPrint(PrintView):
+    model = models.PowerTestRecord
+    template_name = 'hs/power_print.xml'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['filename'] = f"PowerTestRecord_for_{context['object'].event.display_id}.pdf"
+        return context
 
 class EventCheckIn(generic.CreateView, ModalURLMixin):
     model = models.EventCheckIn


### PR DESCRIPTION
# Feature

Allows for the export of PDFs, similar to how Risk Assessments can be exported, but for power test records from events.

This generates a two page document, the first page comprising of high level event detail such as:
- Power MIC
- Event date
- Power Test time
- Venue
- Generator use (from RA)
- Powering other companies (from RA)

The second page contains all the inputted values from the power test plan in a format similar to the HTML version.

![image](https://github.com/user-attachments/assets/23da7764-954b-429f-b17d-16eef2da8777)

Review status of the results is reflected on the first page, the table containing worst points scales depending on how many are inputted/stored.

## Future Improvements

Speaking with Nick today in future it might be nice to expand power test records more with:
- Tracking the user who created the power test record/adding a field to select the crew member who performed the tests
- Allowing for multiple power test records to be attached to one event (e.g. for different venues/electrical environments)

# Miscellaneous

This PR also fixes the fact that exported PDFs never had a total number of pages, it would always say something like "Page 2 of 0", adding a `<namedString>` fixes this, we previously had a reference to this namedString but it didn't exist so the default of `0` was used.

![image](https://github.com/user-attachments/assets/5fdf41e2-876c-43ec-8457-4176b39e2441)
