### PR TITLE
Link to event details from check-in notice

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <div class="col-sm-12">
     {% for event in now %}
     <div class="alert alert-primary rounded-0">
-    Event {{ event }} is happening today! <a href="{% url 'event_checkin' event.pk %}" class="btn btn-success btn-sm modal-href align-baseline {% if request.user.current_event %}disabled{%endif%}"><span class="fas fa-user-clock"></span> <span class="d-none d-sm-inline">Check In</span></a><br/>
+    Event <a href="{% url 'event_detail' event.pk %}" class="text-danger">{{ event }}</a> is happening today! <a href="{% url 'event_checkin' event.pk %}" class="btn btn-success btn-sm modal-href align-baseline {% if request.user.current_event %}disabled{%endif%}"><span class="fas fa-user-clock"></span> <span class="d-none d-sm-inline">Check In</span></a><br/>
     </div>
     {% endfor %}
     </div>


### PR DESCRIPTION
Again a feature requested earlier today.

This hyperlinks the check-in notice so you can quickly browse event details before checking in.

![image](https://github.com/user-attachments/assets/d0d6ef55-0c18-44d1-88d7-43ac383810e6)
