### PR TITLE
Finance dashboard

### DIFF
--- a/PyRIGS/settings.py
+++ b/PyRIGS/settings.py
@@ -224,6 +224,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+USE_THOUSAND_SEPARATOR = True
+
 # Need to allow seconds as datetime-local input type spits out a time that has seconds
 DATETIME_INPUT_FORMATS = ('%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S')
 

--- a/RIGS/management/commands/generateSampleRIGSData.py
+++ b/RIGS/management/commands/generateSampleRIGSData.py
@@ -254,7 +254,7 @@ class Command(BaseCommand):
                             new_invoice.void = True
                         elif random.randint(0, 2) > 1:  # 1 in 3 have been paid
                             models.Payment.objects.create(invoice=new_invoice, amount=new_invoice.balance,
-                                                          date=datetime.date.today())
+                                                          date=datetime.date.today(), method=random.choice(models.Payment.METHODS)[0])
             if i == 1 or random.randint(0, 5) > 0:  # Event 1 and 1 in 5 have a RA
                 models.RiskAssessment.objects.create(event=new_event, supervisor_consulted=bool(random.getrandbits(1)),
                                                      nonstandard_equipment=bool(random.getrandbits(1)),

--- a/RIGS/templates/base_rigs.html
+++ b/RIGS/templates/base_rigs.html
@@ -45,6 +45,7 @@
         Invoices <span class="badge {% if todo == 0 %}badge-success{% else %}badge-danger{% endif %} badge-pill">{{ todo }}</span>
       </a>
       <div class="dropdown-menu" aria-labelledby="navbarDropdownInvoices">
+        <a class="dropdown-item" href="{% url 'invoice_dashboard' %}"><span class="fas fa-chart-line"></span> Dashboard</a>
         {% if perms.RIGS.add_invoice %}
         <a class="dropdown-item text-nowrap" href="{% url 'invoice_waiting' %}"><span class="fas fa-briefcase text-danger"></span> Waiting <span class="badge {% if waiting == 0 %}badge-success{% else %}badge-danger{% endif %} badge-pill">{{ waiting }}</span></a>
         {% endif %}

--- a/RIGS/templates/invoice_dashboard.html
+++ b/RIGS/templates/invoice_dashboard.html
@@ -28,16 +28,20 @@
 
 <div class="card-deck">
     <div class="card">
-        <div class="card-body bg-info">
-            <h5 class="card-title text-center">Total Outstanding</h5>
-            <p class="card-text text-center h3"><strong>£{{ total_outstanding|floatformat:2 }}</strong></p>
-        </div>
+        <a href="{% url 'invoice_waiting' %}" class="text-decoration-none text-white">
+            <div class="card-body bg-primary">
+                <h5 class="card-title text-center">Total Waiting</h5>
+                <p class="card-text text-center h3"><strong>£{{ total_waiting|floatformat:2 }}</strong></p>
+            </div>
+        </a>
     </div>
     <div class="card">
-        <div class="card-body bg-primary">
-            <h5 class="card-title text-center">Total Waiting</h5>
-            <p class="card-text text-center h3"><strong>£{{ total_waiting|floatformat:2 }}</strong></p>
-        </div>
+        <a href="{% url 'invoice_list' %}" class="text-decoration-none text-dark">
+            <div class="card-body bg-info">
+                <h5 class="card-title text-center">Total Outstanding</h5>
+                <p class="card-text text-center h3"><strong>£{{ total_outstanding|floatformat:2 }}</strong></p>
+            </div>
+        </a>
     </div>
     <div class="card">
         <div class="card-body bg-danger">

--- a/RIGS/templates/invoice_dashboard.html
+++ b/RIGS/templates/invoice_dashboard.html
@@ -1,0 +1,101 @@
+{% extends 'base_rigs.html' %}
+
+{% block content %}
+
+<form method="GET" action="{% url 'invoice_dashboard' %}">
+    <div class="form-row">
+        <div class="form-group col-md-4">
+            <label for="time_filter">Time Filter</label>
+            <select id="time_filter" name="time_filter" class="form-control">
+                <option value="week" {% if time_filter == 'week' %}selected{% endif %}>Last Week (7 days)</option>
+                <option value="month" {% if time_filter == 'month' %}selected{% endif %}>Last Month (30 days)</option>
+                <option value="year" {% if time_filter == 'year' %}selected{% endif %}>Last Year</option>
+                <option value="all" {% if time_filter == 'all' %}selected{% endif %}>All Time</option>
+            </select>
+        </div>
+    </div>
+</form>
+
+<script>
+    $('#time_filter').change(function () {
+        $(this).closest('form').submit();
+    });
+</script>
+
+<h3>Overview</h3>
+
+<!-- big cards in 2x2 grid with total_outstanding, total_events, total_invoices and total_payments, different backgrounds -->
+
+<div class="card-deck">
+    <div class="card">
+        <div class="card-body bg-info">
+            <h5 class="card-title text-center">Total Outstanding</h5>
+            <p class="card-text text-center h3"><strong>£{{ total_outstanding|floatformat:2 }}</strong></p>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body bg-primary">
+            <h5 class="card-title text-center">Total Waiting</h5>
+            <p class="card-text text-center h3"><strong>£{{ total_waiting|floatformat:2 }}</strong></p>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body bg-danger">
+            <h5 class="card-title text-center">Total Events</h5>
+            <p class="card-text text-center h3"><strong>{{ total_events }}</strong></p>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body bg-success">
+            <h5 class="card-title text-center">Total Invoices</h5>
+            <p class="card-text text-center h3"><strong>{{ total_invoices }}</strong></p>
+        </div>
+    </div>
+</div>
+
+<br />
+
+<h3>Payments</h3>
+
+<br/>
+
+<h4>Sources</h4>
+
+<br/>
+
+{% for source in payment_methods %}
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title"><strong>{{ source.method }}</strong></h5>
+        <p class="card-text h3">£{{ source.total|floatformat:2 }}</p>
+    </div>
+</div>
+{% endfor %}
+
+<br/>
+
+<h4>Total</h4>
+
+<br/>
+
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title text-center">Total Income</h5>
+        <p class="card-text text-center h3"><strong>£{{ total_income|floatformat:2 }}</strong></p>
+    </div>
+</div>
+
+<br/>
+
+<h4>Invoice Payment Time</h4>
+
+<br/>
+
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title text-center">Average Time to Pay</h5>
+        <p class="card-text text-center h3"><strong>{{ mean_invoice_to_payment|floatformat:2 }} days</strong></p>
+    </div>
+</div>
+
+{% endblock %}

--- a/RIGS/urls.py
+++ b/RIGS/urls.py
@@ -115,7 +115,8 @@ urlpatterns = [
     path('event/webhook/', views.RecieveForumWebhook.as_view(), name='webhook_recieve'),
 
     # Finance
-    path('invoice/', permission_required_with_403('RIGS.view_invoice')(views.InvoiceIndex.as_view()),
+    path('invoice/', permission_required_with_403('RIGS.view_invoice')(views.InvoiceDashboard.as_view()), name='invoice_dashboard'),
+    path('invoice/outstanding', permission_required_with_403('RIGS.view_invoice')(views.InvoiceOutstanding.as_view()),
          name='invoice_list'),
     path('invoice/archive/', permission_required_with_403('RIGS.view_invoice')(views.InvoiceArchive.as_view()),
          name='invoice_archive'),


### PR DESCRIPTION
Adds a new finance dashboard requested by Alfie which should allow for some interesting figures to be presented in the upcoming General Meeting.

![image](https://github.com/user-attachments/assets/cefcc555-ad9e-4b1b-92af-aa508349fb16)

This follows the same RBAC as other routes within the invoices section of the application so only trusted users can view this information.

Time periods allow for figures to be viewed for all time, for the last week, month or year.

The above screenshot misattributes payment sources as they are not part of the seeded data generated by the bootstrap script, though this data is accurately attributed in production.