### PR TITLE
Fix vertical centering of navbar logo

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark" role="navigation">
   <div class="container">
       <a class="navbar-brand" href="{% if request.user.is_authenticated %}https://rigs.nottinghamtec.co.uk{%else%}https://nottinghamtec.co.uk{%endif%}">
-        <img src="{% static 'imgs/logo.webp' %}" class="mr-auto" style="max-height: 40px; position: absolute; left: 0.5em; top: 0;" alt="TEC's Logo: Serif 'TEC' vertically next to a blue box with the words 'PA and Lighting', surrounded by graduated rings" id="logo">
+        <img src="{% static 'imgs/logo.webp' %}" class="mr-auto" style="max-height: 40px;" alt="TEC's Logo: Serif 'TEC' vertically next to a blue box with the words 'PA and Lighting', surrounded by graduated rings" id="logo">
       </a>
       {% block titleheader %}
       {% endblock %}


### PR DESCRIPTION
Commit 6d53df0c8bf24b44be76a8f0ef82ade86079f6f6 tried to address the logo leaking out of the navbar but incidentally seems to have pinned it to the top of the navbar.

Removing all manual positioning seems to leave Bootstrap happy enough to style it and so with just `max-height: 40px;` I see the following behavior in Firefox and Chromium.

![image](https://github.com/user-attachments/assets/f45c2d2b-d043-490d-bee9-5acf78b4399c)

```diff
diff --git a/templates/base.html b/templates/base.html
index 9c73904..3cd53e1 100644
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark" role="navigation">
   <div class="container">
       <a class="navbar-brand" href="{% if request.user.is_authenticated %}https://rigs.nottinghamtec.co.uk{%else%}https://nottinghamtec.co.uk{%endif%}">
-        <img src="{% static 'imgs/logo.webp' %}" class="mr-auto" style="max-height: 40px; position: absolute; left: 0.5em; top: 0;" alt="TEC's Logo: Serif 'TEC' vertically next to a blue box with the words 'PA and Lighting', surrounded by graduated rings" id="logo">
+        <img src="{% static 'imgs/logo.webp' %}" class="mr-auto" style="max-height: 40px;" alt="TEC's Logo: Serif 'TEC' vertically next to a blue box with the words 'PA and Lighting', surrounded by graduated rings" id="logo">
       </a>
       {% block titleheader %}
       {% endblock %}
```

I can't really figure out what would cause the rendering discrepancies on other platforms.