### PR TITLE
Allow sorting and filtering by Profile.date_joined in Django admin

### DIFF
--- a/RIGS/admin.py
+++ b/RIGS/admin.py
@@ -154,9 +154,9 @@ class AssociateAdmin(VersionAdmin):
 
 @admin.register(models.Profile)
 class ProfileAdmin(UserAdmin, AssociateAdmin):
-    list_display = ('username', 'name', 'is_approved', 'is_superuser', 'is_supervisor', 'number_of_events', 'last_login')
+    list_display = ('username', 'name', 'is_approved', 'is_superuser', 'is_supervisor', 'number_of_events', 'last_login', 'date_joined')
     list_display_links = ['username']
-    list_filter = UserAdmin.list_filter + ('is_approved',)
+    list_filter = UserAdmin.list_filter + ('is_approved', 'date_joined')
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {


### PR DESCRIPTION
Allow sorting and filtering by `date_joined` in the Django admin section of the webpage.

![image](https://github.com/user-attachments/assets/b7c4800a-8106-4629-b7aa-0fc3da90fcdb)

![image](https://github.com/user-attachments/assets/6d3fda6b-4974-4117-97a4-adc0de44cf5a)


Closes #605 