### PR TITLE
Power test export refactoring

### DIFF
--- a/RIGS/templates/hs/power_print.xml
+++ b/RIGS/templates/hs/power_print.xml
@@ -2,8 +2,13 @@
 {% load filters %}
 
 {% block extrastyles %}
-<paraStyle name="style.powerReviewed" alignment="center" backColor="green" textColor="white"/>
-<paraStyle name="style.powerUnreviewed" alignment="center" backColor="red" textColor="white"/>
+<paraStyle name="style.powerReviewed" borderPadding="3" alignment="center" backColor="green" textColor="white"/>
+<paraStyle name="style.powerUnreviewed" borderPadding="3" alignment="center" backColor="red" textColor="white"/>
+<paraStyle name="style.smallText" fontSize="8"/>
+
+<paraStyle leftIndent="2in" rightIndent="2in" name="style.smallEvent" fontSize="10" alignment="center" backColor="green" textColor="white" borderPadding="4" borderColor="black"/>
+<paraStyle leftIndent="2in" rightIndent="2in" name="style.mediumEvent" fontSize="10" alignment="center" backColor="orange" textColor="white" borderPadding="4" borderColor="black"/>
+<paraStyle leftIndent="2in" rightIndent="2in" name="style.largeEvent" fontSize="10" alignment="center" backColor="red" textColor="white" borderPadding="4" borderColor="black"/>
 
 <blockTableStyle id="powerTable">
     <blockValign value="middle"/>
@@ -11,6 +16,10 @@
     <lineStyle kind="LINEBELOW" colorName="black" thickness="1"/>
     <lineStyle kind="LINEAFTER" colorName="black" thickness="1"/>
     <lineStyle kind="LINEBEFORE" colorName="black" thickness="1"/>
+</blockTableStyle>
+
+<blockTableStyle id="voltageTable">
+    <blockValign value="middle"/>
 </blockTableStyle>
 {% endblock %}
 
@@ -34,6 +43,16 @@
 <h2 fontSize="16">Power Plan Information</h2>
 <spacer length="15"/>
 
+{% if object.event.riskassessment.event_size == 0 %}
+    <para style="style.smallEvent"><strong>Small Event</strong></para>
+{% elif object.event.riskassessment.event_size == 1 %}
+    <para style="style.mediumEvent"><strong>Medium Event</strong></para>
+{% elif object.event.riskassessment.event_size == 2 %}
+    <para style="style.largeEvent"><strong>Large Event</strong></para>
+{% endif %}
+    
+<spacer length="15"/>
+
 <blockTable colWidths="250,250">
     <tr>
         <td><para><strong>Power MIC:</strong> {{ object.power_mic }}</para></td>
@@ -54,35 +73,56 @@
 <hr/>
 <spacer length="15"/>
 
+{% comment %}
+0 - Small event
+1 - Medium event (extra power records)
+2 - Large event (extra power records)
+{% endcomment %}
+
+{% if object.event.riskassessment.event_size >= 1 %}
+
+<para alignment="center"><strong>Power Test results enclosed on next page</strong></para>
+
 <condPageBreak height="10in"/>
 
-<h2 fontSize="16">Power Test Results</h2>
+<h2 fontSize="16">Event Power Checklist</h2>
 <spacer length="15"/>
 
-<para><strong>Source RCD protected?</strong> {{ object.source_rcd|yesno|capfirst }}</para>
-<para><sub>(If cable is more than 3 metres long)</sub></para>
-
-<spacer length="5"/>
-
-<para><strong>Appropriate and clear labelling on distribution and cabling?</strong> {{ object.labelling|yesno|capfirst }}</para>
-
-<spacer length="5"/>
-
-<para><strong>Equipment appropriately earthed?</strong> {{ object.source_rcd|yesno|capfirst }}</para>
-<para><sub>(truss, stage, generators etc.)</sub></para>
-
-<spacer length="5"/>
-
-<para><strong>All equipment in PAT period?</strong> {{ object.pat|yesno|capfirst }}</para>
+<blockTable colWidths="250,270" style="powerTable">
+    <tr>
+        <td><para><strong>All circuit RCDs tested?</strong></para><para style="style.smallText">(using test button)</para></td>
+        <td><para>{{ object.all_rcds_tested|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Public/performer accessible circuits tested?</strong></para><para style="style.smallText">(using socket tester)</para></td>
+        <td><para>{{ object.public_sockets_tested|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Source RCD protected?</strong></para><para style="style.smallText">(if cable is more than 3m long)</para></td>
+        <td><para>{{ object.source_rcd|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Appropriate and clear labelling on distribution and cabling?</strong></para></td>
+        <td><para>{{ object.labelling|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Equipment appropriately earthed?</strong></para><para style="style.smallText">(truss, stage, generators, etc.)</para></td>
+        <td><para>{{ object.earthing|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>All equipment in PAT period?</strong><br/><br/></para></td>
+        <td><para>{{ object.pat|yesno|capfirst }}</para></td>
+    </tr>
+</blockTable>
 
 <spacer length="15"/>
 
-<h2 fontSize="14">Tests at first distro</h2>
+<h2 fontSize="14">Power tests (First Distro)</h2>
 <spacer length="5"/>
 
-<blockTable colWidths="100,410">
+<blockTable colWidths="100,410" style="voltageTable">
 <tr>
-<td><para><strong>Voltage<br/><sub>(cube meter) / V</sub></strong></para></td>
+<td><para><strong>Voltage</strong></para><para style="style.smallText">(cube meter) / V</para></td>
 <td>
     <blockTable colWidths="100,100,100" style="powerTable">
         <tr>
@@ -100,11 +140,11 @@
 </tr>
 </blockTable>
 
-<spacer length="15"/>
+<spacer length="10"/>
 
-<blockTable colWidths="100,100,190,120">
+<blockTable colWidths="100,100,190,120" style="voltageTable">
     <tr>
-        <td><para><strong>Phase Rotation<br/><sub>(if required)</sub></strong></para></td>
+        <td><para><strong>Phase Rotation</strong></para><para style="style.smallText">(if required)</para></td>
         <td><para>{{ object.fd_phase_rotation|yesno|capfirst }}</para></td>
                 <td><para><strong>Earth Fault Loop Impedance (Z<sub>s</sub>) / Ω</strong></para></td>
         <td><para>{{ object.fd_earth_fault }}</para></td>
@@ -113,11 +153,11 @@
 
 <spacer length="15"/>
 
-<para><strong>Prospective Short Circuit Current / A</strong> {{ object.fd_pssc }}</para>
+<para><strong>Prospective Short Circuit Current (PSCC)</strong> {{ object.fd_pssc }} A</para>
 
 <spacer length="15"/>
 
-<h2 fontSize="14">Tests 'Worst Case' points (at least 1 required)</h2>
+<h2 fontSize="14">Power Tests (Worst Case Points)</h2>
 <spacer length="15"/>
 
 <blockTable colWidths="100,100,190,120" style="powerTable">
@@ -153,18 +193,33 @@
     {% endif %}
 </blockTable>
 
-<spacer length="15"/>
-<h2 fontSize="14">Generic Tests</h2>
+{% else %}
+
+{% comment %}
+Small power test
+{% endcomment %}
+
+<h2 fontSize="16">Power Checklist</h2>
 <spacer length="15"/>
 
 <blockTable colWidths="250,270" style="powerTable">
     <tr>
-        <td><para><strong>All circuit RCDs tested?</strong><br/>(using test button)</para></td>
-        <td><para>{{ object.all_rcds_tested|yesno|capfirst }}</para></td>
+        <td><para><strong>RCDs installed where needed and tested?</strong><br/><br/></para></td>
+        <td><para>{{ object.rcds|yesno|capfirst }}</para></td>
     </tr>
     <tr>
-        <td><para><strong>Public/performer accessible circuits tested?</strong><br/>(using socket tester)</para></td>
-        <td><para>{{ object.public_sockets_tested|yesno|capfirst }}</para></td>
+        <td><para><strong>Electrical supplies tested?</strong><br/><br/></para></td>
+        <td><para>{{ object.supply_test|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>Equipment appropriately earthed?</strong></para><para style="style.smallText">(truss, stage, generators, etc.)</para></td>
+        <td><para>{{ object.earthing|yesno|capfirst }}</para></td>
+    </tr>
+    <tr>
+        <td><para><strong>All equipment in PAT period?</strong><br/><br/></para></td>
+        <td><para>{{ object.pat|yesno|capfirst }}</para></td>
     </tr>
 </blockTable>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
- Handle small power test exports instead of exporting a medium/large copy with empty values
- Reformat the medium/large power tests for better legibility (e.g. checklists are easier to read with alignment now)
- Event size is now displayed on the export under the power plan meta section

Small Power Test:

![image](https://github.com/user-attachments/assets/f2f8b629-8fde-498a-9865-424442ebec27)

Medium/Large Power Test:

![image](https://github.com/user-attachments/assets/596718e7-3adf-4c68-abe2-b3f23f0744eb)
![image](https://github.com/user-attachments/assets/0532a453-53d3-42ee-86ec-b6fa445a74d0)
