### PR TITLE
Show crew list on event checklist view

### DIFF
--- a/RIGS/templates/event_detail.html
+++ b/RIGS/templates/event_detail.html
@@ -1,7 +1,6 @@
 {% extends request.is_ajax|yesno:"base_ajax.html,base_rigs.html" %}
 
 {% load markdown_tags %}
-{% load button from filters %}
 {% load static %}
 
 {% block content %}
@@ -57,43 +56,9 @@
                 </div>
             </div>
         </div>
-        {% if event.can_check_in %}
-        <div class="col-sm-12">
-            <div class="card mt-3">
-                <div class="card-header">Crew Record</div>
-                <div class="table-responsive">
-                    <table class="table table-sm">
-                        <thead>
-                            <tr>
-                                <th scope="col">Name</th>
-                                <th scope="col">Vehicle</th>
-                                <th scope="col">Start Time</th>
-                                <th scope="col">Role</th>
-                                <th scope="col">End Time</th>
-                                <th scope="col">{% if request.user.pk is event.mic.pk %}<a href="{% url 'event_checkin_override' event.pk %}" class="btn btn-sm btn-success"><span class="fas fa-plus"></span> Add</a>{% endif %}</th>
-                            </tr>
-                        </thead>
-                        <tbody id="crewmembers">
-                            {% for crew in object.crew.all %}
-                            <tr>
-                                <td>{{crew.person}}</td>
-                                <td>{{crew.vehicle|default:"None"}}</td>
-                                <td>{{crew.time}}</td>
-                                <td>{{crew.role}}</td>
-                                <td>{% if crew.end_time %}{{crew.end_time}}{% else %}<span class="text-success fas fa-clock" data-toggle="tooltip" title="This person is currently checked into this event"></span>{% endif %}</td>
-                                <td>{% if crew.end_time %}{% if crew.person.pk == request.user.pk or event.mic.pk == request.user.pk %}{% button 'edit' 'edit_checkin' crew.pk clazz='btn-sm modal-href' %}{% endif %}{%endif%}</td>
-                            </tr>
-                            {% empty %}
-                            <tr>
-                                <td colspan="6" class="text-center bg-warning">Apparently this event happened by magic...</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                    </div>
-            </div>
-            {% endif %}
-        </div>
+        
+        {% include 'partials/crew_list.html' %}
+
         {% if not request.is_ajax and perms.RIGS.view_event %}
         <div class="col-sm-12 text-right">
             {% include 'partials/event_detail_buttons.html' %}

--- a/RIGS/templates/hs/event_checklist_detail.html
+++ b/RIGS/templates/hs/event_checklist_detail.html
@@ -69,8 +69,11 @@
             </div>
         </div>
     </div>
+
+    {% include 'partials/crew_list.html' with event=object.event %}
 </div>
-<div class="col-12 text-right">
+
+<div class="col-12 text-right mt-4">
 {% button 'edit' url='ec_edit' pk=object.pk %}
 {% button 'view' url='event_detail' pk=object.pk text="Event" %}
 <a href="{% url 'event_pt' object.event.pk %}" class="btn btn-info"><span class="fas fa-paperclip"></span> <span

--- a/RIGS/templates/partials/crew_list.html
+++ b/RIGS/templates/partials/crew_list.html
@@ -1,0 +1,48 @@
+{% load button from filters %}
+
+{% if event.can_check_in %}
+<div class="col-sm-12">
+    <div class="card mt-3">
+        <div class="card-header">Crew Record</div>
+        <div class="table-responsive">
+            <table class="table table-sm">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Vehicle</th>
+                        <th scope="col">Start Time</th>
+                        <th scope="col">Role</th>
+                        <th scope="col">End Time</th>
+                        <th scope="col">{% if request.user.pk is event.mic.pk %}<a
+                                href="{% url 'event_checkin_override' event.pk %}" class="btn btn-sm btn-success"><span
+                                    class="fas fa-plus"></span> Add</a>{% endif %}</th>
+                    </tr>
+                </thead>
+                <tbody id="crewmembers">
+                    {% for crew in event.crew.all %}
+                    <tr>
+                        <td>{{crew.person}}</td>
+                        <td>{{crew.vehicle|default:"None"}}</td>
+                        <td>{{crew.time}}</td>
+                        <td>{{crew.role}}</td>
+                        <td>{% if crew.end_time %}
+                            {{crew.end_time}}
+                            {% else %}
+                            <span class="text-success fas fa-clock" data-toggle="tooltip"
+                                title="This person is currently checked into this event"></span>{% endif %}
+                        </td>
+                        <td>{% if crew.end_time %}{% if crew.person.pk == request.user.pk or event.mic.pk ==
+                            request.user.pk %}{% button 'edit' 'edit_checkin' crew.pk clazz='btn-sm modal-href' %}{%
+                            endif %}{% endif %}</td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="6" class="text-center bg-warning">Apparently this event happened by magic...</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}


### PR DESCRIPTION
As requested in #582 and on the Forum.

![image](https://github.com/user-attachments/assets/24c76966-43be-4cb8-8613-ce31e64f6570)

Very similar to @bobbinz initial implementation except split into a partial to prevent unnecessary duplication and some margin changes around buttons so that the table isn't too tightly packed against other content on the checklist page.

Closes #582.