### PR TITLE
fix: use earliest time instead of start time

### DIFF
--- a/RIGS/models.py
+++ b/RIGS/models.py
@@ -512,7 +512,7 @@ class Event(models.Model, RevisionMixin):
     def can_check_in(self):
         earliest = self.earliest_time
         if isinstance(self.earliest_time, datetime.date):
-            earliest = datetime.datetime.combine(self.start_date, datetime.time(00, 00))
+            earliest = datetime.datetime.combine(self.earliest_time, datetime.time(00, 00))
             tz = pytz.timezone(settings.TIME_ZONE)
             earliest = tz.localize(earliest)
         return not self.dry_hire and not self.status == Event.CANCELLED and earliest <= timezone.now()


### PR DESCRIPTION
Here we're checking if the `earliest_time` is a date and doesn't contain a time, yet when we add midnight to this date, we're adding it to `start_date` instead of `earliest_date`. 

At the moment this means that on events which have an access time earlier than the same day, rigs doesn't show check in options like it should on the specific rig page, yet the option is shown on the homepage.

Fixed to make the behaviour consistent (allow check in on rig page)