### PR TITLE
Remove missed async attributes

### DIFF
--- a/assets/templates/asset_list.html
+++ b/assets/templates/asset_list.html
@@ -12,7 +12,7 @@
 
 {% block preload_js %}
     {{ block.super }}
-    <script src="{% static 'js/selects.js' %}" async></script>
+    <script src="{% static 'js/selects.js' %}"></script>
 {% endblock %}
 
 {% block js %}

--- a/assets/templates/cable_list.html
+++ b/assets/templates/cable_list.html
@@ -11,7 +11,7 @@
 
 {% block preload_js %}
     {{ block.super }}
-    <script src="{% static 'js/selects.js' %}" async></script>
+    <script src="{% static 'js/selects.js' %}"></script>
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
Removes the two async attributes I missed in #629. Should fix the filter select inputs not appearing on the asset list/search page.