### PR TITLE
Check for union account on rigboard

### DIFF
--- a/RIGS/templates/partials/event_status.html
+++ b/RIGS/templates/partials/event_status.html
@@ -13,7 +13,11 @@
                 <span class="badge badge-danger">Authorisation: <span class="fas fa-times"></span></span>
             {% endif %}
         {% else %}  
+            {% if event.purchase_order %}
                 <span class="badge badge-success">PO: Received</span>
+            {% else %}
+                <span class="badge badge-danger">PO: <span class="fas fa-times"></span></span>
+            {%endif %}
         {%endif %}
     {% endif %}
     {% if not event.dry_hire %}

--- a/RIGS/templates/partials/event_status.html
+++ b/RIGS/templates/partials/event_status.html
@@ -14,7 +14,7 @@
             {% endif %}
         {% else %}  
             {% if event.purchase_order %}
-                <span class="badge badge-success">PO: Received</span>
+                <span class="badge badge-success">PO: Received <span class="fas fa-check"></span></span>
             {% else %}
                 <span class="badge badge-danger">PO: <span class="fas fa-times"></span></span>
             {%endif %}

--- a/RIGS/templates/partials/event_status.html
+++ b/RIGS/templates/partials/event_status.html
@@ -2,17 +2,19 @@
 <span class="badge badge-{% if event.confirmed %}success{% elif event.cancelled %}dark{% else %}warning{% endif %}">Status: {{ event.get_status_display }}</span>
 {% if event.is_rig %}
     {% if event.sum_total > 0 %}
-        {% if event.purchase_order %}
-            <span class="badge badge-success">PO: Received</span>
-        {% elif event.authorised %}
-            <span class="badge badge-success">Authorisation: Complete <span class="fas fa-check"></span></span>
-        {% elif event.authorisation and event.authorisation.amount != event.total and event.authorisation.last_edited_at > event.auth_request_at %}
-            <span class="badge badge-warning"> Authorisation: Issue <span class="fas fa-exclamation-circle"></span></span>
-        {% elif event.auth_request_to %}
-            <span class="badge badge-info"> Authorisation: Sent <span class="fas fa-paper-plane"></span></span>
-        {% else %}
-            <span class="badge badge-danger">Authorisation: <span class="fas fa-times"></span></span>
-        {% endif %}
+        {% if event.organisation.union_account %}
+            {% if event.authorised %}
+                <span class="badge badge-success">Authorisation: Complete <span class="fas fa-check"></span></span>
+            {% elif event.authorisation and event.authorisation.amount != event.total and event.authorisation.last_edited_at > event.auth_request_at %}
+                <span class="badge badge-warning"> Authorisation: Issue <span class="fas fa-exclamation-circle"></span></span>
+            {% elif event.auth_request_to %}
+                <span class="badge badge-info"> Authorisation: Sent <span class="fas fa-paper-plane"></span></span>
+            {% else %}
+                <span class="badge badge-danger">Authorisation: <span class="fas fa-times"></span></span>
+            {% endif %}
+        {% else %}  
+                <span class="badge badge-success">PO: Received</span>
+        {%endif %}
     {% endif %}
     {% if not event.dry_hire %}
         {% if event.riskassessment %}


### PR DESCRIPTION
Additional if statement on the rigboard to check if the organisation has a union account and show "Authorisation" or "PO" language respectively. At the moment "PO Recieved" is only shown when a PO is inputted, it should also been shown if authorisation is not possible (No SU account).

Now when an org doesn't have an SU account and a PO hasn't been inputted, instead of showing "Authorisation ❌️" it shows "PO ❌️" for consistency. Authorisation is still shown as normal for all SU groups.

The diff is horrendous on GitHub, vscode does a better job of showing what's actually changed:


<img width="1251" height="541" alt="Screenshot 2026-04-16 at 2 17 33 pm" src="https://github.com/user-attachments/assets/a8dde424-3711-4e8e-8b51-96c83386aacc" />

<img width="51" height="32" alt="Screenshot 2026-04-16 at 2 21 05 pm" src="https://github.com/user-attachments/assets/13e2b664-78dc-4f19-b298-d40232860504" />
